### PR TITLE
Update discount paint.txt

### DIFF
--- a/data/all/discount paint.txt
+++ b/data/all/discount paint.txt
@@ -19,7 +19,7 @@ mission "Discount Paint Set"
     job
     repeat
     to offer
-        has "Discount Paint Prompt: offered"
+        has "Discount Paint Clear: offered"
         not "enabled paint trim jobs"
     on accept
         dialog `Paint trim jobs have been enabled.`


### PR DESCRIPTION
Hopefully should allow paint prompts to unlock again, fixing a bug (?) that permanently disabled them when disabling paint trim jobs